### PR TITLE
Merged in newer versions of the base simplesamlphp files that are used by sildisco

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ vendor/
 local.env
 development/codeception/tests/_output/
 development/codeception/tests/_support/_generated/
+
+/testOutput/*.html
+/testOutput/*.png
+/testOutput/failed
+/testOutput/debug/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -269,6 +269,7 @@ services:
       - ./development/codeception/tests:/data/tests
       - ./development/browser_test/composer.json:/data/composer.json
       - ./development/browser_test/composer.lock:/data/composer.lock
+      - ./testOutput/:/data/tests/_output/
     depends_on:
       - phantomjs   
     ports:

--- a/lib/Auth/Process/TrackIdps.php
+++ b/lib/Auth/Process/TrackIdps.php
@@ -23,12 +23,12 @@ class TrackIdps extends \SimpleSAML\Auth\ProcessingFilter {
         if ( ! $sessionValue) {
             $sessionValue = [];
         }
-    
+
         // Will we need to wrap the idp in htmlspecialchars()
         $authIdps = $session->getAuthData("hub-discovery", "saml:AuthenticatingAuthority");
 
         if ( ! in_array($authIdps[0], $sessionValue)) {
-            $sessionValue[] = $authIdps[0];
+            $sessionValue[$authIdps[0]] = $authIdps[0];
         }
     
         $session->setData($sessionDataType, $sessionKey, $sessionValue); 

--- a/lib/Auth/Source/SP.php
+++ b/lib/Auth/Source/SP.php
@@ -2,8 +2,10 @@
 
 /**
  * Modified from origin: modules/saml/lib/Auth/Source/SP.php
- * 2020-04-20 -- Merged with simplesamlphp 1.18.6, lines/sections marked with GTIS are modified
+ * 2022-09-26 -- Merged with simplesamlphp 1.19.6, lines/sections marked with GTIS are modified
  */
+
+declare(strict_types=1);
 
 namespace SimpleSAML\Module\sildisco\Auth\Source; // GTIS
 
@@ -65,7 +67,7 @@ class SP extends \SimpleSAML\Auth\Source
     /**
      * A list of supported protocols.
      *
-     * @var array
+     * @var string[]
      */
     private $protocols = [];
 
@@ -145,7 +147,7 @@ class SP extends \SimpleSAML\Auth\Source
         ];
 
         // add NameIDPolicy
-        if ($this->metadata->hasValue('NameIDValue')) {
+        if ($this->metadata->hasValue('NameIDPolicy')) {
             $format = $this->metadata->getValue('NameIDPolicy');
             if (is_array($format)) {
                 $metadata['NameIDFormat'] = Configuration::loadFromArray($format)->getString(
@@ -196,7 +198,7 @@ class SP extends \SimpleSAML\Auth\Source
         }
 
         // add contacts
-        $contacts = $this->metadata->getArray('contact', []);
+        $contacts = $this->metadata->getArray('contacts', []);
         foreach ($contacts as $contact) {
             $metadata['contacts'][] = Utils\Config\Metadata::getContact($contact);
         }
@@ -225,15 +227,10 @@ class SP extends \SimpleSAML\Auth\Source
                 'X509Certificate' => $certInfo['certData'],
                 'prefix' => 'new_',
                 'url' => Module::getModuleURL(
-//                    'admin/federation/cert',
-//                    [
-//                        'set' => 'saml20-sp-hosted',
-//                        'source' => $this->getAuthId(),
-//                        'prefix' => 'new_'
-//                    ]
-                    'admin/cert',
+                    'admin/federation/cert',
                     [
-                        'sp' => $this->getAuthId(),
+                        'set' => 'saml20-sp-hosted',
+                        'source' => $this->getAuthId(),
                         'prefix' => 'new_'
                     ]
                 ),
@@ -250,15 +247,10 @@ class SP extends \SimpleSAML\Auth\Source
                 'X509Certificate' => $certInfo['certData'],
                 'prefix' => '',
                 'url' => Module::getModuleURL(
-//                    'admin/federation/cert',
-//                    [
-//                        'set' => 'saml20-sp-hosted',
-//                        'source' => $this->getAuthId(),
-//                        'prefix' => ''
-//                    ]
-                    'admin/cert',
+                    'admin/federation/cert',
                     [
-                        'sp' => $this->getAuthId(),
+                        'set' => 'saml20-sp-hosted',
+                        'source' => $this->getAuthId(),
                         'prefix' => ''
                     ]
                 ),
@@ -282,7 +274,7 @@ class SP extends \SimpleSAML\Auth\Source
         }
 
         // add signature options
-        if ($this->metadata->hasValue('WantAssertiosnsSigned')) {
+        if ($this->metadata->hasValue('WantAssertionsSigned')) {
             $metadata['saml20.sign.assertion'] = $this->metadata->getBoolean('WantAssertionsSigned');
         }
         if ($this->metadata->hasValue('redirect.sign')) {
@@ -362,8 +354,13 @@ class SP extends \SimpleSAML\Auth\Source
      * @return array
      * @throws \Exception
      */
-    private function getACSEndpoints()
+    private function getACSEndpoints(): array
     {
+        // If a list of endpoints is specified in config, take that at face value
+        if ($this->metadata->hasValue('AssertionConsumerService')) {
+            return $this->metadata->getArray('AssertionConsumerService');
+        }
+
         $endpoints = [];
         $default = [
             Constants::BINDING_HTTP_POST,
@@ -444,7 +441,7 @@ class SP extends \SimpleSAML\Auth\Source
      * @return array
      * @throws \SimpleSAML\Error\CriticalConfigurationError
      */
-    private function getSLOEndpoints()
+    private function getSLOEndpoints(): array
     {
         $store = Store::getInstance();
         $bindings = $this->metadata->getArray(
@@ -454,7 +451,8 @@ class SP extends \SimpleSAML\Auth\Source
                 Constants::BINDING_SOAP,
             ]
         );
-        $location = Module::getModuleURL('saml/sp/saml2-logout.php/' . $this->getAuthId());
+        $defaultLocation = Module::getModuleURL('saml/sp/saml2-logout.php/' . $this->getAuthId());
+        $location = $this->metadata->getString('SingleLogoutServiceLocation', $defaultLocation);
 
         $endpoints = [];
         foreach ($bindings as $binding) {
@@ -479,7 +477,7 @@ class SP extends \SimpleSAML\Auth\Source
      * @return void
      * @deprecated will be removed in a future version
      */
-    private function startSSO1(Configuration $idpMetadata, array $state)
+    private function startSSO1(Configuration $idpMetadata, array $state): void
     {
         $idpEntityId = $idpMetadata->getString('entityid');
 
@@ -517,7 +515,7 @@ class SP extends \SimpleSAML\Auth\Source
      * @param array $state  The state array for the current authentication.
      * @return void
      */
-    private function startSSO2(Configuration $idpMetadata, array $state)
+    private function startSSO2(Configuration $idpMetadata, array $state): void
     {
         if (isset($state['saml:ProxyCount']) && $state['saml:ProxyCount'] < 0) {
             Auth\State::throwException(
@@ -563,7 +561,6 @@ class SP extends \SimpleSAML\Auth\Source
         if (isset($state['saml:Audience'])) {
             $ar->setAudiences($state['saml:Audience']);
         }
-
         if (isset($state['ForceAuthn'])) {
             $ar->setForceAuthn((bool) $state['ForceAuthn']);
         }
@@ -664,9 +661,19 @@ class SP extends \SimpleSAML\Auth\Source
 
         $ar->setRequesterID($requesterID);
 
-        if (isset($state['saml:Extensions'])) {
+        // If the downstream SP has set extensions then use them.
+        // Otherwise use extensions that might be defined in the local SP (only makes sense in a proxy scenario)
+        if (isset($state['saml:Extensions']) && count($state['saml:Extensions']) > 0) {
             $ar->setExtensions($state['saml:Extensions']);
+        } else if ($this->metadata->getArray('saml:Extensions', null) !== null) {
+            $ar->setExtensions($this->metadata->getArray('saml:Extensions'));
         }
+
+        $providerName = $this->metadata->getString("ProviderName", null);
+        if ($providerName !== null) {
+            $ar->setProviderName($providerName);
+        }
+
 
         // save IdP entity ID as part of the state
         $state['ExpectedIssuer'] = $idpMetadata->getString('entityid');
@@ -758,7 +765,7 @@ class SP extends \SimpleSAML\Auth\Source
      * @param array $state  The state array.
      * @return void
      */
-    private function startDisco(array $state)
+    private function startDisco(array $state): void
     {
         $id = Auth\State::saveState($state, 'saml:sp:sso');
 
@@ -859,6 +866,7 @@ class SP extends \SimpleSAML\Auth\Source
     {
         $session = Session::getSessionFromRequest();
         $data = $session->getAuthState($this->authId);
+        $data = $session->getAuthState($this->authId);
         if ($data === null) {
             throw new Error\NoState();
         }
@@ -875,12 +883,16 @@ class SP extends \SimpleSAML\Auth\Source
 
         $spEntityId = $state['SPMetadata']['entityid'];
         $IDPList = array_keys(DiscoUtils::getIdpsForSp($spEntityId, $metadataPath));
+ die("111111111111: " . sizeof($IDPList) . " ... " . var_export($IDPList, true) . PHP_EOL );
 
         if (sizeof($IDPList) > 1) {
             $state['LoginCompletedHandler'] = array(SP::class, 'reauthPostLogin');
             $this->authenticate($state);
             assert(false);
         }
+
+
+die("AAAAAAAA: " . var_export($IDPList, true) . " ... " . $state['saml:sp:IdP'] . "<<<");
 
 
         // GTIS  Changed this if block to avoid logging out before authenticating
@@ -901,6 +913,7 @@ class SP extends \SimpleSAML\Auth\Source
             $state['LoginCompletedHandler'] = array(SP::class, 'reauthPostLogin');
             $this->authenticate($state);
         }
+        // End GTIS
     }
 
 

--- a/lib/Auth/Source/SP.php
+++ b/lib/Auth/Source/SP.php
@@ -883,17 +883,12 @@ class SP extends \SimpleSAML\Auth\Source
 
         $spEntityId = $state['SPMetadata']['entityid'];
         $IDPList = array_keys(DiscoUtils::getIdpsForSp($spEntityId, $metadataPath));
- die("111111111111: " . sizeof($IDPList) . " ... " . var_export($IDPList, true) . PHP_EOL );
 
         if (sizeof($IDPList) > 1) {
             $state['LoginCompletedHandler'] = array(SP::class, 'reauthPostLogin');
             $this->authenticate($state);
             assert(false);
         }
-
-
-die("AAAAAAAA: " . var_export($IDPList, true) . " ... " . $state['saml:sp:IdP'] . "<<<");
-
 
         // GTIS  Changed this if block to avoid logging out before authenticating
         //    with a new IdP

--- a/sspoverrides/www_saml2_idp/SSOService.php
+++ b/sspoverrides/www_saml2_idp/SSOService.php
@@ -1,7 +1,7 @@
 <?php
 /**
  *
- * Note: This has been copied from the core code (www/saml2/idp/SSOService.php)
+ * Note: This has been copied from the core code (www/saml2/idp/SSOService.php version 1.19.6)
  *   and modified to call a different authentication class/method
  *
  * Original comments ...
@@ -19,10 +19,15 @@ require_once('../../_include.php');
 \SimpleSAML\Logger::info('SAML2.0 - IdP.SSOService: Accessing SAML 2.0 IdP endpoint SSOService');
 
 $metadata = \SimpleSAML\Metadata\MetaDataStorageHandler::getMetadataHandler();
+
+$config = \SimpleSAML\Configuration::getInstance();
+if (!$config->getBoolean('enable.saml20-idp', false) || !\SimpleSAML\Module::isModuleEnabled('saml')) {
+    throw new \SimpleSAML\Error\Error('NOACCESS', null, 403);
+}
+
 $idpEntityId = $metadata->getMetaDataCurrentEntityID('saml20-idp-hosted');
 $idp = \SimpleSAML\IdP::getById('saml2:' . $idpEntityId);
 
-$config = \SimpleSAML\Configuration::getConfig();
 $hubModeKey = 'hubmode';
 
 try {

--- a/www/sp/discoresp.php
+++ b/www/sp/discoresp.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Modified version of modules/saml/www/sp/discoresp.php
- * 2020-04-20 -- merged with SimpleSAMLphp 1.18.6
+ * 2022-09-26 -- merged with SimpleSAMLphp 1.19.6
  */
 
 /**

--- a/www/sp/saml2-logout.php
+++ b/www/sp/saml2-logout.php
@@ -6,7 +6,7 @@
  * This endpoint handles both logout requests and logout responses.
  *
  * Similar to modules/saml/www/sp/saml2-logout.php
- * 2020-04-20 -- Merged with simplesamlphp 1.18.6, lines marked with GTIS are modified
+ * 2022-09-26 -- Merged with simplesamlphp 1.19.6, lines marked with GTIS are modified
  */
 
 if (!array_key_exists('PATH_INFO', $_SERVER)) {
@@ -112,6 +112,7 @@ if ($message instanceof \SAML2\LogoutResponse) {
     $nameId = $message->getNameId();
     $sessionIndexes = $message->getSessionIndexes();
 
+    /** @psalm-suppress PossiblyNullArgument  This will be fixed in saml2 5.0 */
     $numLoggedOut = \SimpleSAML\Module\saml\SP\LogoutStore::logoutSessions($sourceId, $nameId, $sessionIndexes);
     if ($numLoggedOut === false) {
         // This type of logout was unsupported. Use the old method


### PR DESCRIPTION
The primary debugging change is in lib/Auth/Process/TrackIdps.php.

For some reason in the past, just building an array with a list of IdP IDs was adequate. Now, they need to be added explicitly as keys, in order to compare them against a specific IdP ID, which is done in sspUtils getReducedIdpList().